### PR TITLE
Accept PENDING and ACCEPTED_ON_L1 as valid tx statuses

### DIFF
--- a/test/sample-test.ts
+++ b/test/sample-test.ts
@@ -15,6 +15,8 @@ import { expectFeeEstimationStructure } from "./util";
   return "0x" + BigInt(address).toString(16);
 }
 
+const OK_TX_STATUSES = ["PENDING", "ACCEPTED_ON_L2", "ACCEPTED_ON_L1"]
+
 /**
  * Expects address equality after adapting them.
  * @param actual 
@@ -211,20 +213,20 @@ describe("Starknet", function () {
     expect(complexResp).to.deep.equal(complexArray);
   });
 
-  it("should retrieve transaction details", async function() {
+  it.only("should retrieve transaction details", async function() {
     const contract = await eventsContractFactory.deploy();
     
     const txHash = await contract.invoke("increase_balance", { amount: 10 });
 
     const tx = await starknet.getTransaction(txHash);
     console.log(tx);
-    expect(tx.status).to.deep.equal("ACCEPTED_ON_L2");
+    expect(tx.status).to.be.oneOf(OK_TX_STATUSES);
     expect(tx.transaction.calldata).to.deep.equal(["0xa"]);
     expectAddressEquality(tx.transaction.contract_address,contract.address);
 
     const receipt = await starknet.getTransactionReceipt(txHash);
     console.log(receipt);
-    expect(receipt.status).to.deep.equal("ACCEPTED_ON_L2");
+    expect(receipt.status).to.be.oneOf(OK_TX_STATUSES);
     expectAddressEquality(receipt.events[0].from_address,contract.address);
     expect(receipt.events[0].data).to.deep.equal(["0x0", "0xa"]);
 

--- a/test/sample-test.ts
+++ b/test/sample-test.ts
@@ -213,7 +213,7 @@ describe("Starknet", function () {
     expect(complexResp).to.deep.equal(complexArray);
   });
 
-  it.only("should retrieve transaction details", async function() {
+  it("should retrieve transaction details", async function() {
     const contract = await eventsContractFactory.deploy();
     
     const txHash = await contract.invoke("increase_balance", { amount: 10 });


### PR DESCRIPTION
Add ACCEPTED_ON_L1 and PENDING to ok statuses. So far only ACCEPTED_ON_L2 was considered ok. This is done using the `oneOf` chai expectation method.