### PR TITLE
Add get-predeployed-accounts test

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -8,12 +8,12 @@ import "@nomiclabs/hardhat-ethers";
 const config: HardhatUserConfig = {
   solidity: '0.6.12',
   starknet: {
-    // dockerizedVersion: "0.8.2", // alternatively choose one of the two venv options below
+    dockerizedVersion: "0.8.2", // alternatively choose one of the two venv options below
     // uses (my-venv) defined by `python -m venv path/to/my-venv`
     // venv: "path/to/my-venv",
 
     // uses the currently active Python environment (hopefully with available Starknet commands!)
-    venv: "active",
+    // venv: "active",
     network: "alpha",
     wallets: {
       OpenZeppelin: {
@@ -30,7 +30,7 @@ const config: HardhatUserConfig = {
     integratedDevnet: {
       url: "http://127.0.0.1:5050",
       // venv: "active",
-      // dockerizedVersion: "0.2.2"
+      dockerizedVersion: "0.2.2"
     },
     hardhat: {}
   },

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -8,12 +8,12 @@ import "@nomiclabs/hardhat-ethers";
 const config: HardhatUserConfig = {
   solidity: '0.6.12',
   starknet: {
-    dockerizedVersion: "0.8.2", // alternatively choose one of the two venv options below
+    // dockerizedVersion: "0.8.2", // alternatively choose one of the two venv options below
     // uses (my-venv) defined by `python -m venv path/to/my-venv`
     // venv: "path/to/my-venv",
 
     // uses the currently active Python environment (hopefully with available Starknet commands!)
-    // venv: "active",
+    venv: "active",
     network: "alpha",
     wallets: {
       OpenZeppelin: {
@@ -30,7 +30,7 @@ const config: HardhatUserConfig = {
     integratedDevnet: {
       url: "http://127.0.0.1:5050",
       // venv: "active",
-      dockerizedVersion: "0.2.2"
+      // dockerizedVersion: "0.2.2"
     },
     hardhat: {}
   },

--- a/test/get-predeployed-accounts.test.ts
+++ b/test/get-predeployed-accounts.test.ts
@@ -1,10 +1,11 @@
 import { expect } from "chai";
 import { starknet } from "hardhat"
+import { TIMEOUT } from "./constants";
 
 describe("Devnet restart", function() {
-    this.timeout(900_000);
+    this.timeout(TIMEOUT);
 
-    it("should pass", async () => {
+    it("should fetch predeployed accounts successfully", async () => {
         const response = await starknet.devnet.getPredeployedAccounts();
         expect(response).to.be.an('array')
         expect(response[0].address).to.be.a('string')

--- a/test/get-predeployed-accounts.test.ts
+++ b/test/get-predeployed-accounts.test.ts
@@ -1,0 +1,15 @@
+import { expect } from "chai";
+import { starknet } from "hardhat"
+
+describe("Devnet restart", function() {
+    this.timeout(900_000);
+
+    it("should pass", async () => {
+        const response = await starknet.devnet.getPredeployedAccounts();
+        expect(response).to.be.an('array')
+        expect(response[0].address).to.be.a('string')
+        expect(response[0].initial_balance).to.be.a('number')
+        expect(response[0].private_key).to.be.a('string')
+        expect(response[0].public_key).to.be.a('string')
+    });
+})


### PR DESCRIPTION
Add get-predeployed-accounts.test.ts, which test the starknet.devnet.getPredeployedAccounts() function. This function fetch pre-deployed accounts and return an array, containing the data of all pre-deployed accounts (which are: address, initial_balance, private and public keys).
