### PR TITLE
Added tests for nested tuples, named tuples, type aliases

### DIFF
--- a/contracts/contract.cairo
+++ b/contracts/contract.cairo
@@ -138,7 +138,7 @@ func dymmy_named_tuple(named_tuple : (a : felt, b : TupleHolder)) -> (
     return (named_tuple)
 end
 
-# ########### nested tuples, named tuples, aliases
+############ nested tuples, named tuples, aliases
 using NestedTypeAlias = (a : felt, b : (c : felt, d : (felt, (felt, felt, felt))))
 using TupleTypeAlias = ((Point, felt), felt, (felt, (felt, Point)))
 

--- a/contracts/contract.cairo
+++ b/contracts/contract.cairo
@@ -15,32 +15,29 @@ func balance() -> (res : felt):
 end
 
 @constructor
-func constructor{
-    syscall_ptr : felt*,
-    pedersen_ptr : HashBuiltin*,
-    range_check_ptr
-} (initial_balance : felt):
+func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    initial_balance : felt
+):
     balance.write(initial_balance)
     return ()
 end
 
 # Increases the balance by the given amount.
 @external
-func increase_balance{
-        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
-        range_check_ptr}(amount1 : felt, amount2 : felt):
+func increase_balance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    amount1 : felt, amount2 : felt
+):
     let (res) = balance.read()
     balance.write(res + amount1 + amount2)
     return ()
 end
 
 @view
-func increase_balance_with_even{
-    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*,
-    range_check_ptr}(amount: felt):
-
+func increase_balance_with_even{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    amount : felt
+):
     let (div, rem) = unsigned_div_rem(amount, 2)
-    assert rem = 0 # assert even
+    assert rem = 0  # assert even
     let (res) = balance.read()
     balance.write(res + amount)
     return ()
@@ -48,9 +45,9 @@ end
 
 # Returns the current balance.
 @view
-func get_balance{
-        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
-        range_check_ptr}() -> (res : felt):
+func get_balance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
+    res : felt
+):
     let (res) = balance.read()
     return (res)
 end
@@ -80,51 +77,43 @@ struct ComplexStruct:
 end
 
 @view
-func dummy_tuple_holder() -> (tuple_holder: TupleHolder):
-    return (
-        tuple_holder=TupleHolder(
-            tuple=(2, 3),
-            extra=4
-        )
-    )
+func dummy_tuple_holder() -> (tuple_holder : TupleHolder):
+    return (tuple_holder=TupleHolder(
+        tuple=(2, 3),
+        extra=4
+        ))
 end
 
 @view
-func identity(a_len: felt, a: felt*) -> (res_len: felt, res: felt*, res_len_squared: felt):
-    return(
-        res_len=a_len,
-        res=a,
-        res_len_squared=a_len * a_len
-    )
+func identity(a_len : felt, a : felt*) -> (res_len : felt, res : felt*, res_len_squared : felt):
+    return (res_len=a_len, res=a, res_len_squared=a_len * a_len)
 end
 
 @view
-func sum_points_to_tuple(points : (Point, Point)) -> (res: (felt, felt)):
-    return (
-        res=(
-            points[0].x + points[1].x,
-            points[0].y + points[1].y
-        )
-    )
+func sum_points_to_tuple(points : (Point, Point)) -> (res : (felt, felt)):
+    return (res=(
+        points[0].x + points[1].x,
+        points[0].y + points[1].y
+        ))
 end
 
 @view
-func sum_point_pair(pointPair: PointPair) -> (res: Point):
+func sum_point_pair(pointPair : PointPair) -> (res : Point):
     return (
         res=Point(
-            x=pointPair.p1.x + pointPair.p2.x + pointPair.extra,
-            y=pointPair.p1.y + pointPair.p2.y + pointPair.extra
-        )
+        x=pointPair.p1.x + pointPair.p2.x + pointPair.extra,
+        y=pointPair.p1.y + pointPair.p2.y + pointPair.extra
+        ),
     )
 end
 
 @view
-func add_extra_to_tuple(tuple_holder: TupleHolder) -> (res: Point):
+func add_extra_to_tuple(tuple_holder : TupleHolder) -> (res : Point):
     return (
         res=Point(
-            x=tuple_holder.tuple[0] + tuple_holder.extra,
-            y=tuple_holder.tuple[1] + tuple_holder.extra
-        )
+        x=tuple_holder.tuple[0] + tuple_holder.extra,
+        y=tuple_holder.tuple[1] + tuple_holder.extra
+        ),
     )
 end
 
@@ -134,11 +123,51 @@ func use_almost_equal(a, b) -> (res):
     return (res)
 end
 
+############ type aliases & named tuples
+using TypeAlias = (a : felt, point : Point)
+
+@view
+func dymmy_alias(alias : TypeAlias) -> (res : TypeAlias):
+    return (alias)
+end
+
+@view
+func dymmy_named_tuple(named_tuple : (a : felt, b : TupleHolder)) -> (
+    res : (a : felt, b : TupleHolder)
+):
+    return (named_tuple)
+end
+
+# ########### nested tuples, named tuples, aliases
+using NestedTypeAlias = (a : felt, b : (c : felt, d : (felt, (felt, felt, felt))))
+using TupleTypeAlias = ((Point, felt), felt, (felt, (felt, Point)))
+
+@view
+func nested_tuple(nested_tuple : (Point, (felt, felt))) -> (res : (Point, (felt, felt))):
+    return (nested_tuple)
+end
+
+@view
+func nested_named_tuple(nested_named_tuple : (x : felt, y : (felt, (felt, felt)))) -> (
+    res : (x : felt, y : (felt, (felt, felt)))
+):
+    return (nested_named_tuple)
+end
+
+@view
+func nested_type_alias(nested_type_alias : NestedTypeAlias) -> (res : NestedTypeAlias):
+    return (nested_type_alias)
+end
+
+@view
+func nested_tuple_type_alias(nested_tuple_type_alias : TupleTypeAlias) -> (res : TupleTypeAlias):
+    return (nested_tuple_type_alias)
+end
+
 ########### arrays
 
 @external
-func sum_array(
-        a_len : felt, a : felt*) -> (res):
+func sum_array(a_len : felt, a : felt*) -> (res):
     if a_len == 0:
         return (res=0)
     end
@@ -147,28 +176,28 @@ func sum_array(
 end
 
 @view
-func increment_point_array(
-        a_len : felt, a : Point*, i : felt) -> (res_len : felt, res : Point*):
+func increment_point_array(a_len : felt, a : Point*, i : felt) -> (res_len : felt, res : Point*):
     alloc_locals
     if a_len == 1:
         let (local struct_array : Point*) = alloc()
-        let (result_len, result) = add_point_to_array(0,struct_array,Point(a[0].x + i, a[0].y + i))
-        return (res_len = result_len, res=result)
+        let (result_len, result) = add_point_to_array(
+            0, struct_array, Point(a[0].x + i, a[0].y + i)
+        )
+        return (res_len=result_len, res=result)
     end
     let (rest_len, rest) = increment_point_array(a_len=a_len - 1, a=a + Point.SIZE, i=i)
     let (result_len, result) = add_point_to_array(rest_len, rest, Point(a[0].x + i, a[0].y + i))
-    return (res_len = result_len, res=result)
+    return (res_len=result_len, res=result)
 end
 
-func add_point_to_array(
-        a_len : felt, a : Point*, r : Point) -> (res_len : felt, res : Point*):
+func add_point_to_array(a_len : felt, a : Point*, r : Point) -> (res_len : felt, res : Point*):
     let res = a
     assert res[a_len] = r
     return (a_len + 1, res)
 end
 
 @view
-func sum_point_array(points_len: felt, points: Point*) -> (res: Point):
+func sum_point_array(points_len : felt, points : Point*) -> (res : Point):
     if points_len == 0:
         return (res=Point(x=0, y=0))
     end
@@ -176,18 +205,20 @@ func sum_point_array(points_len: felt, points: Point*) -> (res: Point):
     return (res=Point(
         x=points[0].x + rest.x,
         y=points[0].y + rest.y
-    ))
+        ))
 end
 
 @view
-func complex_array(
-        a_len : felt, a : Point*, i : felt, b_len : felt, b : ComplexStruct*) -> (points_len : felt, points : Point*, complex_struct_len : felt, complex_struct : ComplexStruct*):
+func complex_array(a_len : felt, a : Point*, i : felt, b_len : felt, b : ComplexStruct*) -> (
+    points_len : felt, points : Point*, complex_struct_len : felt, complex_struct : ComplexStruct*
+):
     return (a_len, a, b_len, b)
 end
 
 @external
 func get_signature{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*}() -> (
-        res_len : felt, res : felt*):
+    res_len : felt, res : felt*
+):
     let (sig_len, sig) = get_tx_signature()
     return (res_len=sig_len, res=sig)
 end

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -6,7 +6,7 @@ import "@nomiclabs/hardhat-ethers";
  * @type import('hardhat/config').HardhatUserConfig
  */
 const config: HardhatUserConfig = {
-  solidity: '0.6.12',
+  solidity: "0.6.12",
   starknet: {
     dockerizedVersion: "0.8.2", // alternatively choose one of the two venv options below
     // uses (my-venv) defined by `python -m venv path/to/my-venv`
@@ -18,21 +18,22 @@ const config: HardhatUserConfig = {
     wallets: {
       OpenZeppelin: {
         accountName: "OpenZeppelin",
-        modulePath: "starkware.starknet.wallets.open_zeppelin.OpenZeppelinAccount",
-        accountPath: "~/.starknet_accounts"
-      }
-    }
+        modulePath:
+          "starkware.starknet.wallets.open_zeppelin.OpenZeppelinAccount",
+        accountPath: "~/.starknet_accounts",
+      },
+    },
   },
   networks: {
     devnet: {
-      url: "http://127.0.0.1:5050"
+      url: "http://127.0.0.1:5050",
     },
     integratedDevnet: {
       url: "http://127.0.0.1:5050",
       // venv: "active",
-      dockerizedVersion: "0.2.2"
+      dockerizedVersion: "0.2.2",
     },
-    hardhat: {}
+    hardhat: {},
   },
 };
 

--- a/test/function-args-test.ts
+++ b/test/function-args-test.ts
@@ -119,93 +119,113 @@ describe("Starknet", function () {
   });
 
   it("should work if providing exact amount of members in type alias", async function () {
-    const { res } = await contract.call("dymmy_alias", {
+    const payload = {
       alias: {
-        a: 1,
+        a: 1n,
         point: {
-          x: 2,
-          y: 2,
+          x: 2n,
+          y: 2n,
         },
       },
-    });
+    };
+    const { res } = await contract.call("dymmy_alias", payload);
 
-    expect(res.a).to.equal(1n);
-    expect(res.point).to.eql({ x: 2n, y: 2n });
+    expect(res).to.deep.equal(payload.alias);
   });
 
   it("should work if providing exact amount of members in named tuple", async function () {
-    const { res } = await contract.call("dymmy_named_tuple", {
+    const payload = {
       named_tuple: {
-        a: 1,
+        a: 1n,
         b: {
-          tuple: [2, 3],
-          extra: 4,
+          tuple: [2n, 3n],
+          extra: 4n,
         },
       },
-    });
+    };
+    const { res } = await contract.call("dymmy_named_tuple", payload);
 
-    expect(res.a).to.equal(1n);
-    expect(res.b.tuple).to.eql([2n, 3n]);
-    expect(res.b.extra).to.equal(4n);
+    expect(res).to.deep.equal(payload.named_tuple);
   });
 
   it("should work if providing exact amount of members in nested tuple", async function () {
-    const { res } = await contract.call("nested_tuple", {
-      nested_tuple: [{ x: 1, y: 2 }, [3, 4]],
-    });
+    const payload = {
+      nested_tuple: [{ x: 1n, y: 2n }, [3n, 4n]],
+    };
+    const { res } = await contract.call("nested_tuple", payload);
 
-    expect(res.length).to.equal(2);
-    expect(res[0]).to.eql({ x: 1n, y: 2n });
-    expect(res[1]).to.eql([3n, 4n]);
+    expect(res).to.deep.equal(payload.nested_tuple);
   });
 
   it("should work if providing exact amount of members in nested named tuple", async function () {
-    const { res } = await contract.call("nested_named_tuple", {
-      nested_named_tuple: { x: 1, y: [2, [3, 4]] },
-    });
+    const payload = {
+      nested_named_tuple: { x: 1n, y: [2n, [3n, 4n]] },
+    };
+    const { res } = await contract.call("nested_named_tuple", payload);
 
-    expect(res.x).to.equal(1n);
-    expect(res.y.length).to.equal(2);
-    expect(res.y[0]).to.equal(2n);
-    expect(res.y[1]).to.eql([3n, 4n]);
+    expect(res).to.deep.equal(payload.nested_named_tuple);
   });
 
   it("should work if providing exact amount of members in nested type alias", async function () {
-    const { res } = await contract.call("nested_type_alias", {
+    const payload = {
       nested_type_alias: {
-        a: 1,
+        a: 1n,
         b: {
-          c: 2,
-          d: [3, [4, 5, 6]],
+          c: 2n,
+          d: [3n, [4n, 5n, 6n]],
         },
       },
-    });
+    };
+    const { res } = await contract.call("nested_type_alias", payload);
 
-    expect(res.a).to.equal(1n);
-    expect(res.b.c).to.equal(2n);
-    expect(res.b.d.length).to.equal(2);
-    expect(res.b.d[0]).to.equal(3n);
-    expect(res.b.d[1]).to.eql([4n, 5n, 6n]);
+    expect(res).to.deep.equal(payload.nested_type_alias);
   });
 
   it("should work if providing exact amount of members in nested tuple type alias", async function () {
-    const { res } = await contract.call("nested_tuple_type_alias", {
+    const payload = {
       nested_tuple_type_alias: [
-        [{ x: 1, y: 2 }, 3],
-        4,
-        [5, [6, { x: 7, y: 8 }]],
+        [{ x: 1n, y: 2n }, 3n],
+        4n,
+        [5n, [6n, { x: 7n, y: 8n }]],
       ],
-    });
+    };
 
-    expect(res.length).to.equal(3);
-    expect(res[0].length).to.equal(2);
-    expect(res[0][0]).to.eql({ x: 1n, y: 2n });
-    expect(res[0][1]).to.equal(3n);
-    expect(res[1]).to.equal(4n);
-    expect(res[2].length).to.equal(2);
-    expect(res[2][0]).to.equal(5n);
-    expect(res[2][1].length).to.equal(2);
-    expect(res[2][1][0]).to.equal(6n);
-    expect(res[2][1][1]).to.eql({ x: 7n, y: 8n });
+    const { res } = await contract.call("nested_tuple_type_alias", payload);
+
+    expect(res).to.deep.equal(payload.nested_tuple_type_alias);
+  });
+
+  it("should fail if provided number of members is less than the expected", async function () {
+    try {
+      await contract.call("nested_tuple_type_alias", {
+        nested_tuple_type_alias: [
+          [{ x: 1n, y: 2n }, 3n],
+          4n,
+          [5n, [{ x: 7n, y: 8n }]],
+        ],
+      });
+      expect.fail("Should have failed on passing too few members.");
+    } catch (err: any) {
+      expect(err.message).to.eql(
+        '"nested_tuple_type_alias[2][1]": Expected 2 members, got 1.'
+      );
+    }
+  });
+
+  it("should fail if provided number of members is more than the expected", async function () {
+    try {
+      await contract.call("nested_tuple_type_alias", {
+        nested_tuple_type_alias: [
+          [{ x: 1n, y: 2n }, 3n],
+          4n,
+          [5n, [6n, { x: 7n, y: 8n }], 9n],
+        ],
+      });
+      expect.fail("Should have failed on passing too few members.");
+    } catch (err: any) {
+      expect(err.message).to.equal(
+        '"nested_tuple_type_alias[2]": Expected 2 members, got 3.'
+      );
+    }
   });
 });

--- a/test/function-args-test.ts
+++ b/test/function-args-test.ts
@@ -1,123 +1,211 @@
 import { expect } from "chai";
 import { starknet } from "hardhat";
 import { TIMEOUT } from "./constants";
-import { StarknetContract, StarknetContractFactory } from "hardhat/types/runtime";
+import {
+  StarknetContract,
+  StarknetContractFactory,
+} from "hardhat/types/runtime";
 
 describe("Starknet", function () {
   this.timeout(TIMEOUT);
   let contractFactory: StarknetContractFactory;
   let contract: StarknetContract;
-  
-  before(async function() {
+
+  before(async function () {
     // assumes contract.cairo has been compiled
     contractFactory = await starknet.getContractFactory("contract");
     contract = await contractFactory.deploy({ initial_balance: 0 });
   });
 
-  it("should work if provided number of arguments is the same as the expected", async function() {
+  it("should work if provided number of arguments is the same as the expected", async function () {
     const { res: balanceBefore } = await contract.call("get_balance");
     expect(balanceBefore).to.deep.equal(0n);
   });
 
-  it("should fail if provided number of arguments is less than the expected", async function() {
+  it("should fail if provided number of arguments is less than the expected", async function () {
     try {
       await contract.call("sum_array");
       expect.fail("Should have failed on passing too few arguments.");
-    } catch(err: any) {
+    } catch (err: any) {
       expect(err.message).to.equal("sum_array: Expected 1 argument, got 0.");
     }
   });
 
-  it("should fail if provided number of arguments is more than the expected", async function() {
+  it("should fail if provided number of arguments is more than the expected", async function () {
     try {
-      await contract.call("sum_array", {a: [1, 2, 3, 4], b: 4 });
+      await contract.call("sum_array", { a: [1, 2, 3, 4], b: 4 });
       expect.fail("Should have failed on passing extra argument.");
-    } catch(err: any) {
+    } catch (err: any) {
       expect(err.message).to.equal("sum_array: Expected 1 argument, got 2.");
     }
   });
 
-  it("should work if not providing the array length when having an array as argument", async function() {
-    const { res: sum } = await contract.call("sum_array", {a: [1, 2, 3, 4] });
+  it("should work if not providing the array length when having an array as argument", async function () {
+    const { res: sum } = await contract.call("sum_array", { a: [1, 2, 3, 4] });
     expect(sum).to.deep.equal(10n);
   });
 
-  it("should fail if providing the array length when having an array as argument", async function() {
+  it("should fail if providing the array length when having an array as argument", async function () {
     try {
-      await contract.call("sum_array", {a_len: 4, a: [1, 2, 3, 4]});
+      await contract.call("sum_array", { a_len: 4, a: [1, 2, 3, 4] });
       expect.fail("Should have failed on passing extra argument.");
-    } catch(err: any) {
+    } catch (err: any) {
       expect(err.message).to.equal("sum_array: Expected 1 argument, got 2.");
     }
   });
 
-  it("should work if providing the exact amount of members in a tuple, with the exact amount of members in a nested struct", async function() {
+  it("should work if providing the exact amount of members in a tuple, with the exact amount of members in a nested struct", async function () {
     const { res: sum } = await contract.call("sum_points_to_tuple", {
       points: [
         { x: 1, y: 2 },
         { x: 3, y: 4 },
-      ]
+      ],
     });
-    expect(sum).to.deep.equal([ 4n, 6n ]);
+    expect(sum).to.deep.equal([4n, 6n]);
   });
 
-  it("should fail if providing too many members in a tuple", async function() {
+  it("should fail if providing too many members in a tuple", async function () {
     try {
       await contract.call("sum_points_to_tuple", {
         points: [
           { x: 1, y: 2 },
           { x: 3, y: 4 },
-          { x: 3, y: 4 }
-        ]
+          { x: 3, y: 4 },
+        ],
       });
       expect.fail("Should have failed on passing more members than expected.");
-    } catch(err: any) {
+    } catch (err: any) {
       expect(err.message).to.equal('"points": Expected 2 members, got 3.');
     }
   });
 
-  it("should fail if providing too few members in a tuple", async function() {
+  it("should fail if providing too few members in a tuple", async function () {
     try {
       // passing Points (1, 2) and (3, 4) in a tuple
       await contract.call("sum_points_to_tuple", {
-        points: [
-          { x: 1, y: 2 }
-        ]
+        points: [{ x: 1, y: 2 }],
       });
       expect.fail("Should have failed on passing less members than expected.");
-    } catch(err: any) {
+    } catch (err: any) {
       expect(err.message).to.equal('"points": Expected 2 members, got 1.');
     }
   });
 
-  it("should fail if providing too few members to a nested struct", async function() {
+  it("should fail if providing too few members to a nested struct", async function () {
     try {
       // passing Points (1, 2) and (3, 4) in a tuple
       await contract.call("sum_points_to_tuple", {
-        points: [
-          { x: 1 },
-          { x: 3, y: 4, z: 5 }
-        ]
+        points: [{ x: 1 }, { x: 3, y: 4, z: 5 }],
       });
       expect.fail("Should have failed on passing less members than expected.");
-    } catch(err: any) {
+    } catch (err: any) {
       expect(err.message).to.equal('"points[0]": Expected 2 members, got 1.');
     }
   });
 
-  it("should fail if providing too many members to a nested struct", async function() {
+  it("should fail if providing too many members to a nested struct", async function () {
     try {
       // passing Points (1, 2) and (3, 4) in a tuple
       await contract.call("sum_points_to_tuple", {
         points: [
-          { x: 1, y: 2},
-          { x: 3, y: 4, z: 5 }
-        ]
+          { x: 1, y: 2 },
+          { x: 3, y: 4, z: 5 },
+        ],
       });
       expect.fail("Should have failed on passing more members than expected");
-    } catch(err: any) {
+    } catch (err: any) {
       expect(err.message).to.equal('"points[1]": Expected 2 members, got 3.');
     }
   });
-  
+
+  it("should work if providing exact amount of members in type alias", async function () {
+    const { res } = await contract.call("dymmy_alias", {
+      alias: {
+        a: 1,
+        point: {
+          x: 2,
+          y: 2,
+        },
+      },
+    });
+
+    expect(res.a).to.equal(1n);
+    expect(res.point).to.eql({ x: 2n, y: 2n });
+  });
+
+  it("should work if providing exact amount of members in named tuple", async function () {
+    const { res } = await contract.call("dymmy_named_tuple", {
+      named_tuple: {
+        a: 1,
+        b: {
+          tuple: [2, 3],
+          extra: 4,
+        },
+      },
+    });
+
+    expect(res.a).to.equal(1n);
+    expect(res.b.tuple).to.eql([2n, 3n]);
+    expect(res.b.extra).to.equal(4n);
+  });
+
+  it("should work if providing exact amount of members in nested tuple", async function () {
+    const { res } = await contract.call("nested_tuple", {
+      nested_tuple: [{ x: 1, y: 2 }, [3, 4]],
+    });
+
+    expect(res.length).to.equal(2);
+    expect(res[0]).to.eql({ x: 1n, y: 2n });
+    expect(res[1]).to.eql([3n, 4n]);
+  });
+
+  it("should work if providing exact amount of members in nested named tuple", async function () {
+    const { res } = await contract.call("nested_named_tuple", {
+      nested_named_tuple: { x: 1, y: [2, [3, 4]] },
+    });
+
+    expect(res.x).to.equal(1n);
+    expect(res.y.length).to.equal(2);
+    expect(res.y[0]).to.equal(2n);
+    expect(res.y[1]).to.eql([3n, 4n]);
+  });
+
+  it("should work if providing exact amount of members in nested type alias", async function () {
+    const { res } = await contract.call("nested_type_alias", {
+      nested_type_alias: {
+        a: 1,
+        b: {
+          c: 2,
+          d: [3, [4, 5, 6]],
+        },
+      },
+    });
+
+    expect(res.a).to.equal(1n);
+    expect(res.b.c).to.equal(2n);
+    expect(res.b.d.length).to.equal(2);
+    expect(res.b.d[0]).to.equal(3n);
+    expect(res.b.d[1]).to.eql([4n, 5n, 6n]);
+  });
+
+  it("should work if providing exact amount of members in nested tuple type alias", async function () {
+    const { res } = await contract.call("nested_tuple_type_alias", {
+      nested_tuple_type_alias: [
+        [{ x: 1, y: 2 }, 3],
+        4,
+        [5, [6, { x: 7, y: 8 }]],
+      ],
+    });
+
+    expect(res.length).to.equal(3);
+    expect(res[0].length).to.equal(2);
+    expect(res[0][0]).to.eql({ x: 1n, y: 2n });
+    expect(res[0][1]).to.equal(3n);
+    expect(res[1]).to.equal(4n);
+    expect(res[2].length).to.equal(2);
+    expect(res[2][0]).to.equal(5n);
+    expect(res[2][1].length).to.equal(2);
+    expect(res[2][1][0]).to.equal(6n);
+    expect(res[2][1][1]).to.eql({ x: 7n, y: 8n });
+  });
 });

--- a/test/sample-test.ts
+++ b/test/sample-test.ts
@@ -170,7 +170,7 @@ describe("Starknet", function () {
   });
 
   it("should deploy to expected address when using salt", async function() {
-    const EXPECTED_ADDRESS = "0x05736c162a7cd243e6e9b417f0c5f8c77006f386e13562986b40e9e51528a6d7";
+    const EXPECTED_ADDRESS = "0x1877d9ab8314cc8559dad694fa943b6e89606413642433f03166d799649f662";
     console.log("Started deployment");
     const contractFactory: StarknetContractFactory = await starknet.getContractFactory("contract");
     const contract: StarknetContract = await contractFactory.deploy({ initial_balance: 0 }, { salt: "0xa0" });


### PR DESCRIPTION
Added tests for named tuples, type aliases and nested tuples
`dummy_alias` - takes as argument simple non-nested alias type.
`dymmy_named_tuple` - takes as argument simple non-nested named tuple.

`nested_tuple` - takes as argument nested tuple 
`nested_named_tuple` - takes as argument nested named tuple
`nested_type_alias` - takes as argument complex alias type
`nested_tuple_type_alias` - takes as argument alias to nested tuple

All of the above as result return passed argument