### PR TITLE
273 tests

### DIFF
--- a/test/contract-factory-test.ts
+++ b/test/contract-factory-test.ts
@@ -1,7 +1,0 @@
-import { starknet } from "hardhat";
-
-describe("ContractFactory", () => {
-    it("should be created", async () => {
-        await starknet.getContractFactory("contract");
-    });
-});

--- a/test/contract-factory.test.ts
+++ b/test/contract-factory.test.ts
@@ -1,0 +1,57 @@
+import { expect } from "chai";
+import { starknet } from "hardhat";
+import { TIMEOUT } from "./constants";
+import { StarknetContractFactory } from "hardhat/types/runtime";
+import { getPredeployedOZAccount } from "./util";
+import { OpenZeppelinAccount } from "@shardlabs/starknet-hardhat-plugin/dist/src/account";
+import * as fs from "fs";
+import { StarknetContract } from "@shardlabs/starknet-hardhat-plugin/dist/src/types";
+
+describe("StarknetContractFactory", function () {
+    this.timeout(TIMEOUT);
+    let contractFactory: StarknetContractFactory;
+    let account: OpenZeppelinAccount;
+    // let contract: StarknetContract;
+
+    before(async function () {
+        account = await getPredeployedOZAccount();
+        contractFactory = await starknet.getContractFactory("contract");
+
+        // contract = await account.deploy(contractFactory, { initial_balance: 0 });
+    });
+    it("should have file at getAbiPath()", async () => {
+        const abiPath = contractFactory.getAbiPath();
+        expect(fs.existsSync(abiPath)).to.be.true;
+    });
+    it("should have abi", async () => {
+        const { abi } = contractFactory;
+        expect(typeof abi).to.be.eq("object");
+        expect(abi).to.not.be.null;
+        expect(Object.keys(abi).length > 0).to.be.true;
+    });
+    it("should have increase_balance in abi", async () => {
+        const { increase_balance } = contractFactory.abi;
+        expect(typeof increase_balance).to.be.eq("object");
+        expect(increase_balance.type).to.be.eq("function");
+    });
+    it("should have file at metadataPath", async () => {
+        const { metadataPath } = contractFactory;
+        expect(fs.existsSync(metadataPath)).to.be.true;
+    });
+    it("should declare class", async () => {
+        // account.declare calls and return contractFactory.declare
+        const classHash = await account.declare(contractFactory);
+        expect(typeof classHash).to.be.eq("string");
+        expect(classHash.indexOf("0x")).to.be.eq(0);
+    });
+    it("should getClassHash", async () => {
+        const classHash = await contractFactory.getClassHash();
+        expect(typeof classHash).to.be.eq("string");
+        expect(classHash.indexOf("0x")).to.be.eq(0);
+    });
+    it("should getContractAt", async () => {
+        const { address } = await account.deploy(contractFactory, { initial_balance: 0 });
+        const contract = contractFactory.getContractAt(address);
+        expect(contract instanceof StarknetContract).to.be.true;
+    });
+});

--- a/test/contract-factory.test.ts
+++ b/test/contract-factory.test.ts
@@ -11,13 +11,10 @@ describe("StarknetContractFactory", function () {
     this.timeout(TIMEOUT);
     let contractFactory: StarknetContractFactory;
     let account: OpenZeppelinAccount;
-    // let contract: StarknetContract;
 
     before(async function () {
         account = await getPredeployedOZAccount();
         contractFactory = await starknet.getContractFactory("contract");
-
-        // contract = await account.deploy(contractFactory, { initial_balance: 0 });
     });
     it("should have file at getAbiPath()", async () => {
         const abiPath = contractFactory.getAbiPath();
@@ -39,7 +36,7 @@ describe("StarknetContractFactory", function () {
         expect(fs.existsSync(metadataPath)).to.be.true;
     });
     it("should declare class", async () => {
-        // account.declare calls and return contractFactory.declare
+        // account.declare() calls and returns contractFactory.declare()
         const classHash = await account.declare(contractFactory);
         expect(typeof classHash).to.be.eq("string");
         expect(classHash.indexOf("0x")).to.be.eq(0);

--- a/test/contract.test.ts
+++ b/test/contract.test.ts
@@ -1,0 +1,66 @@
+import { expect } from "chai";
+import { starknet } from "hardhat";
+import { TIMEOUT } from "./constants";
+import { StarknetContractFactory } from "hardhat/types/runtime";
+import { getPredeployedOZAccount } from "./util";
+import { OpenZeppelinAccount } from "@shardlabs/starknet-hardhat-plugin/dist/src/account";
+import * as fs from "fs";
+import { StarknetContract } from "@shardlabs/starknet-hardhat-plugin/dist/src/types";
+
+describe("StarknetContractFactory", function () {
+    this.timeout(TIMEOUT);
+    let contractFactory: StarknetContractFactory;
+    let account: OpenZeppelinAccount;
+    let contract: StarknetContract;
+    let initial_balance = 25n;
+
+    /**
+ * invoke(functionName: string, args?: StringMap, options?: InvokeOptions): Promise<InvokeResponse>;
+ * call(functionName: string, args?: StringMap, options?: CallOptions): Promise<StringMap>;
+ * estimateFee(functionName: string, args?: StringMap, options?: EstimateFeeOptions): Promise<starknet.FeeEstimation>;
+ * getAbi(): starknet.Abi;
+  decodeEvents(events: starknet.Event[]): DecodedEvent[];
+ */
+
+    before(async function () {
+        account = await getPredeployedOZAccount();
+        contractFactory = await starknet.getContractFactory("contract");
+        contract = await account.deploy(contractFactory, { initial_balance });
+    });
+    it("should have address", async () => {
+        const { address } = account;
+        expect(typeof address).to.be.eq("string");
+        expect(address.indexOf("0x")).to.be.eq(0);
+    });
+    it("should have valid abi getAbi", async () => {
+        const abi = contract.getAbi();
+        expect(typeof abi).to.be.eq("object");
+        expect(typeof abi.increase_balance).to.be.eq("object");
+        expect(abi.increase_balance.type).to.be.eq("function");
+    });
+    it("should call", async () => {
+        const resp = await contract.call("get_balance");
+        console.log(resp);
+        expect(resp.res).to.be.eq(initial_balance);
+    });
+    it("should invoke", async () => {
+        const txnHash = await account.invoke(contract, "increase_balance", {
+            amount1: 20,
+            amount2: 5
+        });
+        expect(typeof txnHash).to.be.eq("string");
+        expect(txnHash.indexOf("0x")).to.be.eq(0);
+    });
+    it("should estimateFee", async () => {
+        const feeEstimation = await account.estimateFee(contract, "increase_balance", {
+            amount1: 20,
+            amount2: 5
+        });
+        expect(typeof feeEstimation.amount).to.be.eq("bigint");
+        expect(typeof feeEstimation.unit).to.be.eq("string");
+        expect(typeof feeEstimation.gas_price).to.be.eq("bigint");
+        expect(typeof feeEstimation.gas_usage).to.be.eq("bigint");
+    });
+
+    // Decode events test in test/decode-events.test.ts
+});

--- a/test/contract.test.ts
+++ b/test/contract.test.ts
@@ -4,7 +4,6 @@ import { TIMEOUT } from "./constants";
 import { StarknetContractFactory } from "hardhat/types/runtime";
 import { getPredeployedOZAccount } from "./util";
 import { OpenZeppelinAccount } from "@shardlabs/starknet-hardhat-plugin/dist/src/account";
-import * as fs from "fs";
 import { StarknetContract } from "@shardlabs/starknet-hardhat-plugin/dist/src/types";
 
 describe("StarknetContractFactory", function () {
@@ -12,15 +11,7 @@ describe("StarknetContractFactory", function () {
     let contractFactory: StarknetContractFactory;
     let account: OpenZeppelinAccount;
     let contract: StarknetContract;
-    let initial_balance = 25n;
-
-    /**
- * invoke(functionName: string, args?: StringMap, options?: InvokeOptions): Promise<InvokeResponse>;
- * call(functionName: string, args?: StringMap, options?: CallOptions): Promise<StringMap>;
- * estimateFee(functionName: string, args?: StringMap, options?: EstimateFeeOptions): Promise<starknet.FeeEstimation>;
- * getAbi(): starknet.Abi;
-  decodeEvents(events: starknet.Event[]): DecodedEvent[];
- */
+    const initial_balance = 25n;
 
     before(async function () {
         account = await getPredeployedOZAccount();
@@ -32,7 +23,7 @@ describe("StarknetContractFactory", function () {
         expect(typeof address).to.be.eq("string");
         expect(address.indexOf("0x")).to.be.eq(0);
     });
-    it("should have valid abi getAbi", async () => {
+    it("should have valid abi: getAbi", async () => {
         const abi = contract.getAbi();
         expect(typeof abi).to.be.eq("object");
         expect(typeof abi.increase_balance).to.be.eq("object");

--- a/test/util.ts
+++ b/test/util.ts
@@ -65,3 +65,24 @@ export async function getOZAccount() {
         OZ_ACCOUNT_PRIVATE_KEY
     );
 }
+
+/**
+ * Returns a predeployed account details.
+ * @returns {PredeployedAccount}
+ */
+export async function getPredeployedAccount() {
+    const accounts = await starknet.devnet.getPredeployedAccounts();
+    return accounts[0];
+}
+
+/**
+ * Returns a predeployed instance of OZAccount.
+ * @returns {OpenZeppelinAccount}
+ */
+export async function getPredeployedOZAccount() {
+    const account = await getPredeployedAccount();
+    return await starknet.OpenZeppelinAccount.getAccountFromAddress(
+        account.address,
+        account.private_key
+    );
+}

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,3 +1,5 @@
+import { OpenZeppelinAccount } from "@shardlabs/starknet-hardhat-plugin/dist/src/account";
+import { PredeployedAccount } from "@shardlabs/starknet-hardhat-plugin/dist/src/devnet-utils";
 import axios from "axios";
 import { expect } from "chai";
 import { starknet } from "hardhat";
@@ -67,20 +69,20 @@ export async function getOZAccount() {
 }
 
 /**
- * Returns a predeployed account details.
- * @returns {PredeployedAccount}
+ * Returns details for a pre-deployed account.
+ * @param {number} index Index of account to use
  */
-export async function getPredeployedAccount() {
+export async function getPredeployedAccount(index = 0): Promise<PredeployedAccount> {
     const accounts = await starknet.devnet.getPredeployedAccounts();
-    return accounts[0];
+    return accounts[index];
 }
 
 /**
- * Returns a predeployed instance of OZAccount.
- * @returns {OpenZeppelinAccount}
+ * Returns an OZAccount instance for a pre-deployed account.
+ * @param {number} index Index of account to use
  */
-export async function getPredeployedOZAccount() {
-    const account = await getPredeployedAccount();
+export async function getPredeployedOZAccount(index = 0): Promise<OpenZeppelinAccount> {
+    const account = await getPredeployedAccount(index);
     return await starknet.OpenZeppelinAccount.getAccountFromAddress(
         account.address,
         account.private_key


### PR DESCRIPTION
For Shard-Labs/starknet-hardhat-plugin#273

Adds tests for `StarknetContract` and `StarknetContractFactory`.
and utilities to get pre-deployed accounts.